### PR TITLE
fix: company address gstin in DN cancel ewb api

### DIFF
--- a/gst_india/cleartax_integration/API/ewb.py
+++ b/gst_india/cleartax_integration/API/ewb.py
@@ -329,7 +329,7 @@ def cancel_ewb_dn(**kwargs):
             else:
                 headers['token'] = settings.get_password('production_auth_token')
         deliver_note = frappe.get_doc('Delivery Note', kwargs.get('delivery_note'))
-        gstin = frappe.get_value('Address', deliver_note.dispatch_address_name,'gstin')
+        gstin = frappe.get_value('Address', deliver_note.company_address,'gstin')
         data = json.loads(kwargs.get('data'))
         data = {
                     "ewbNo": deliver_note.ewaybill,


### PR DESCRIPTION
While Generating EWB, API passes Company Address gstin in headers
But when cancelling the EWB, API passes the Dispatch Address gstin in headers.
So unable to cancel the ewb, if company and dispatch address has different gstin
![Screenshot from 2024-11-27 10-54-06](https://github.com/user-attachments/assets/bbe17418-60c5-4808-9328-3b145abdce40)
